### PR TITLE
feat: add corsconfig to allow frontend website to use backend

### DIFF
--- a/src/main/java/com/example/music_recommendation_api/util/CorsConfig.java
+++ b/src/main/java/com/example/music_recommendation_api/util/CorsConfig.java
@@ -1,0 +1,33 @@
+package com.example.music_recommendation_api.util;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(false);
+        config.setAllowedOrigins(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "OPTIONS"));
+
+        config.setAllowedHeaders(List.of("*"));
+
+        config.setExposedHeaders(List.of(
+                "Access-Control-Allow-Origin",
+                "Access-Control-Allow-Credentials"));
+
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
cors policy util class - allows for the front end to make requests of the back end, which was previously being blocked by the default cors policy